### PR TITLE
Redraw map when map tab is selected

### DIFF
--- a/app/js/app/fullscreen.app.controller.js
+++ b/app/js/app/fullscreen.app.controller.js
@@ -2,9 +2,9 @@
   'use strict';
   angular.module('cityInfo').controller('FullscreenController', FullscreenController);
 
-  FullscreenController.$inject = ['$scope'];
+  FullscreenController.$inject = ['$scope', '$timeout'];
 
-  function FullscreenController($scope) {
+  function FullscreenController($scope, $timeout) {
     var vm = this;
 
     var dragStartListener = null;
@@ -21,6 +21,14 @@
     vm.hidePoiDetails = hidePoiDetails;
 
     $scope.$on('mapReady', onMapReady);
+
+    $scope.$watch('tab', function(newVal, oldVal) {
+      if (newVal === 1 && vm.map !== null) {
+        $timeout(function () {
+          vm.map.forceRedraw();
+        }, 50);
+      }
+    });
 
     function onMapReady(e, map) {
       e.preventDefault();

--- a/app/js/app/fullscreen.app.controller.js
+++ b/app/js/app/fullscreen.app.controller.js
@@ -26,7 +26,7 @@
       if (newVal === 1 && vm.map !== null) {
         $timeout(function () {
           vm.map.forceRedraw();
-        }, 50);
+        }, 750);
       }
     });
 


### PR DESCRIPTION
Map often becomes grey if the screen is resized while it's not onscreen, for example when screen is rotated while another tab is selected. Or atleast it does with desktop Chrome.

This fixes it by manually telling the map to resize / redraw itself when the tab is selected. Apparently I already had a function for that already in place from earlier tests with making the map resizable. A small delay is added to make sure that the map element is visible when forceRedraw is called.

